### PR TITLE
backgroundPageに外部と通信するためのメソッドを追加

### DIFF
--- a/packages/react-devtools-extensions/chrome/manifest.json
+++ b/packages/react-devtools-extensions/chrome/manifest.json
@@ -32,7 +32,7 @@
     "scripts": [
       "build/background.js"
     ],
-    "persistent": false
+    "persistent": true
   },
   "permissions": [
     "file:///*",

--- a/packages/react-devtools-extensions/popups/development.html
+++ b/packages/react-devtools-extensions/popups/development.html
@@ -22,3 +22,11 @@
 <p>
   Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
 </p>
+
+<div>
+  <button id="refresh_component_name_area">Refresh</button>
+  <div class="field">
+    <label>Loaded Components</label>
+    <pre id="component_name_area"></pre>
+  </div>
+</div>

--- a/packages/react-devtools-extensions/popups/production.html
+++ b/packages/react-devtools-extensions/popups/production.html
@@ -18,6 +18,8 @@
 
 <div>
   <button id="refresh_component_name_area">Refresh</button>
-  <pre id="component_name_area">
-  </pre>
+  <div class="field">
+    <label>Loaded Components</label>
+    <pre id="component_name_area"></pre>
+  </div>
 </div>

--- a/packages/react-devtools-extensions/popups/production.html
+++ b/packages/react-devtools-extensions/popups/production.html
@@ -15,3 +15,9 @@
   <br />
   Open the developer tools, and  "Components" and "Profiler" tabs will appear to the right.
 </p>
+
+<div>
+  <button id="refresh_component_name_area">Refresh</button>
+  <pre id="component_name_area">
+  </pre>
+</div>

--- a/packages/react-devtools-extensions/popups/shared.js
+++ b/packages/react-devtools-extensions/popups/shared.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const area = document.getElementById('component_name_area');
             console.log('shared.js area:', area);
             if (area) {
-              area.innerHTML = response.nameSet.join('\n');
+              area.innerHTML = JSON.stringify(response.namesMap, null, 2);
             }
           } else {
             console.log(

--- a/packages/react-devtools-extensions/popups/shared.js
+++ b/packages/react-devtools-extensions/popups/shared.js
@@ -22,4 +22,34 @@ document.addEventListener('DOMContentLoaded', function() {
   requestAnimationFrame(function() {
     document.body.style.opacity = 1;
   });
+
+  const button = document.getElementById('refresh_component_name_area');
+  console.log('shared.js button:', button);
+  if (button) {
+    button.addEventListener('click', () => {
+      console.log('shared.js clicked');
+      const msg = chrome.runtime.sendMessage(
+        {
+          source: 'shared.js',
+          queryReactComponents: true,
+        },
+        response => {
+          console.log('shared.js resp:', response);
+          if (response) {
+            const area = document.getElementById('component_name_area');
+            console.log('shared.js area:', area);
+            if (area) {
+              area.innerHTML = response.nameSet.join('\n');
+            }
+          } else {
+            console.log(
+              'shared.js chrome.runtime.lastError:',
+              chrome.runtime.lastError
+            );
+          }
+        }
+      );
+      console.log('shared.js sendMessage result:', msg);
+    });
+  }
 });

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -155,7 +155,8 @@ class ReactComponentPool {
 }
 
 const reactComponentPool = new ReactComponentPool();
-window.reactComponentPool = reactComponentPool;
+window.setReactComponentPoolKey = key => reactComponentPool.setKey(key);
+window.getReactComponents = () => reactComponentPool.all();
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // console.log('background.js Received from content script:', {request, sender});

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -117,6 +117,10 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 });
 
 chrome.runtime.onMessage.addListener((request, sender) => {
+  console.log('background.js Received message from content script:', request);
+  console.log('background.js process.env', process.env);
+  console.log('background.js process.cwd()', process.cwd());
+
   const tab = sender.tab;
   if (tab) {
     const id = tab.id;

--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -7,6 +7,7 @@ const ports = {};
 const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0;
 
 chrome.runtime.onConnect.addListener(function(port) {
+  console.log('background.js chrome.runtime.onConnect port:', port);
   let tab = null;
   let name = null;
   if (isNumeric(port.name)) {
@@ -116,36 +117,84 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   }
 });
 
-const reactComponentDisplayNames = new Set();
+class ReactComponentPool {
+  constructor() {
+    console.log('background.js ReactComponentPool is created');
+    this._impl = undefined;
+    this.storageKey = 'react-component-pool';
+  }
+  get impl() {
+    if (this._impl === undefined) {
+      // const raw = localStorage.getItem(this.storageKey) || '[]';
+      // this._impl = JSON.parse(raw);
+      this._impl = [];
+    }
+    return this._impl;
+  }
+
+  save() {
+    if (this._impl === undefined) return;
+    // localStorage.setItem(this.storageKey, JSON.stringify(this._impl));
+    console.log('background.js ReactComponentPool.save done');
+  }
+
+  add(component) {
+    if (!this.impl.includes(component)) {
+      console.log('background.js ReactComponentPool.add', component);
+      this.impl.push(component);
+      this.save();
+    }
+  }
+  all() {
+    console.log('background.js ReactComponentPool.all');
+    return this.impl.sort();
+  }
+}
+
+const reactComponentPool = new ReactComponentPool();
+window.getReactComponentDisplayNames = () => {
+  const res = reactComponentPool.all();
+  console.log('background.js getReactComponentDisplayNames', res);
+  return res;
+};
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  console.log('background.js Received from content script:', {request, sender});
+  // console.log('background.js Received from content script:', {request, sender});
 
   // console.log('background.js Received message from content script:', request);
   // console.log('background.js process.env', process.env);
   // console.log('background.js process.cwd()', process.cwd());
 
-  const tab = sender.tab;
-  if (tab) {
-    const id = tab.id;
-    // This is sent from the hook content script.
-    // It tells us a renderer has attached.
-    if (request.reactComponent) {
-      reactComponentDisplayNames.add(request.element.displayName);
-      // console.log(
-      //   'background.js Received reactComponent message',
-      //   request.element.displayName,
-      // );
-      console.log(
-        'background.js reactComponentDisplayNames',
-        reactComponentDisplayNames,
-      );
-      // localStorage.set(
-      //   'reactComponentDisplayNames',
-      //   JSON.stringify(reactComponentDisplayNames),
-      // );
-      return true;
-    } else {
+  if (request.reactComponent) {
+    console.log('background.js Received to add component sender:', sender);
+    reactComponentPool.add(request.element.displayName);
+    // console.log(
+    //   'background.js Received reactComponent message',
+    //   request.element.displayName,
+    // );
+    // localStorage.set(
+    //   'reactComponentDisplayNames',
+    //   JSON.stringify(reactComponentDisplayNames),
+    // );
+    return true;
+  } else if (request.queryReactComponents) {
+    // sendResponse(reactComponentDisplayNames);
+    // sendResponse({response: 'バックグラウンドスクリプトからの応答です'});
+    // return true;
+    // return Promise.resolve({
+    //   response: 'バックグラウンドスクリプトからの応答です',
+    // });
+
+    // setTimeout(function() {
+    sendResponse({nameSet: reactComponentPool.all()});
+    // }, 100);
+    return true;
+  } else {
+    const tab = sender.tab;
+    if (tab) {
+      const id = tab.id;
+      // This is sent from the hook content script.
+      // It tells us a renderer has attached.
       // console.log('background.js Received from content script:', request);
       if (request.hasDetectedReact) {
         // We use browserAction instead of pageAction because this lets us
@@ -167,24 +216,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         return true;
       }
     }
-  } else {
-    if (request.queryReactComponents) {
-      console.log(
-        'background.js Received queryReactComponents reactComponentDisplayNames:',
-        reactComponentDisplayNames,
-      );
-      // sendResponse(reactComponentDisplayNames);
-      // sendResponse({response: 'バックグラウンドスクリプトからの応答です'});
-      // return true;
-      // return Promise.resolve({
-      //   response: 'バックグラウンドスクリプトからの応答です',
-      // });
-
-      // setTimeout(function() {
-      sendResponse({nameSet: Array.from(reactComponentDisplayNames).sort()});
-      // }, 100);
-      return true;
-    }
   }
+
   return true;
 });

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -915,6 +915,9 @@ export default class Store extends EventEmitter<{|
       i += nextLength;
     }
 
+    console.log('store.js process.env', process.env);
+    console.log('store.js process.cwd()', process.cwd());
+
     while (i < operations.length) {
       const operation = operations[i];
       switch (operation) {
@@ -1048,6 +1051,8 @@ export default class Store extends EventEmitter<{|
               type,
               weight: 1,
             };
+
+            console.log('store.js element.displayName', element.displayName);
 
             this._idToElement.set(id, element);
             addedElementIDs.push(id);

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -10,6 +10,7 @@
 import EventEmitter from '../events';
 import {inspect} from 'util';
 import {
+  CHROME_WEBSTORE_EXTENSION_ID,
   PROFILING_FLAG_BASIC_SUPPORT,
   PROFILING_FLAG_TIMELINE_SUPPORT,
   TREE_OPERATION_ADD,
@@ -1052,6 +1053,10 @@ export default class Store extends EventEmitter<{|
               weight: 1,
             };
 
+            chrome.runtime.sendMessage({
+              reactComponent: true,
+              element: element,
+            });
             console.log('store.js element.displayName', element.displayName);
 
             this._idToElement.set(id, element);

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -123,6 +123,8 @@ export default function Element({data, index, style}: Props) {
     type,
   } = ((element: any): ElementType);
 
+  console.log('Element.js element', element);
+
   // Only show strict mode non-compliance badges for top level elements.
   // Showing an inline badge for every element in the tree would be noisy.
   const showStrictModeBadge = isStrictModeNonCompliant && depth === 0;


### PR DESCRIPTION
## 主な機能

- background.js に `getReactComponents` と `setReactComponentPoolKey` を追加
- `setReactComponentPoolKey` はコンポーネント名をプールするためのキーを設定します
- `getReactComponents` は extension が知っているReactのコンポーネント名(displayName) を返します
    - 戻り値のデータの例 [react_component_names.json.txt](https://github.com/groovenauts/react/files/9492901/react_component_names.json.txt)


### キーとは

background.js が取得するコンポーネントの情報には、使用しているページを判別する情報がありません。
複数のページを開いている場合、複数のページで使われているReactコンポーネント名が混じってしまいます。
それを防ぐために、外部から `setReactComponentPoolKey` を使って開こうとしているページを識別する文字列をキーとして予め指定し、コンポーネントの情報を得たときには指定されたキー毎の配列に追加します。
このキーのデフォルト値は `default` です。

## その他の機能

ポップアップに `Refresh` ボタンを追加しました。クリックすると、取得しているコンポーネントの情報を表示します。

<img width="525" alt="スクリーンショット 2022-09-06 11 12 23" src="https://user-images.githubusercontent.com/18912/188532452-306493c6-7ee8-4757-8a19-b14292b4e7d2.png">
<img width="540" alt="スクリーンショット 2022-09-06 11 12 45" src="https://user-images.githubusercontent.com/18912/188532483-aba28b65-5400-4f10-8784-1d15f53c04d2.png">
